### PR TITLE
determine size of device image by weight instead of fixed size

### DIFF
--- a/app/src/main/res/layout/activity_device_info.xml
+++ b/app/src/main/res/layout/activity_device_info.xml
@@ -7,7 +7,8 @@
 
     <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="150dp">
+        android:layout_height="0dp"
+        android:layout_weight="1.6">
 
         <TextView
             android:id="@+id/downloadImageView"


### PR DESCRIPTION
Fix #47 